### PR TITLE
Added method xhtml.storeExternalImagesLocally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changelog
   content from an 'http' or equivalent path to the absolute path on the FileSystem
   to the .blob image file.
   [gbastien]
+- Added method xhtml.storeExternalImagesLocally that will ensure that externally
+  referenced images are downloaded, stored locally and xhtmlContent is adapted
+  accordingly.
+  [gbastien]
 
 
 0.4.14 (2016-02-25)

--- a/src/imio/helpers/tests/test_xhtml.py
+++ b/src/imio/helpers/tests/test_xhtml.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from os import path
 
+from Products.ATContentTypes.interfaces import IImageContent
+
 from imio.helpers.testing import IntegrationTestCase
 from imio.helpers.xhtml import addClassToLastChildren
 from imio.helpers.xhtml import imagesToPath
@@ -333,3 +335,29 @@ class TestXHTMLModule(IntegrationTestCase):
         text = '<p>Image absolute path <img src="http://nohost/plone/img"/> '\
                'and relative path <img src="../img"/>.</p>'
         self.assertEquals(storeExternalImagesLocally(doc, text), text)
+
+        # link to unexisting external image, site exists but not image (error 404) nothing changed
+        text = '<p>Unexisting external image <img src="http://www.imio.be/unexistingimage.png"/></p>.'
+        self.assertEquals(storeExternalImagesLocally(doc, text), text)
+
+        # link to unexisting site, nothing changed
+        text = '<p>Unexisting external site <img src="http://www.unexistingsite.be/unexistingimage.png"/>.</p>'
+        self.assertEquals(storeExternalImagesLocally(doc, text), text)
+
+        # working example
+        text = '<p>Working external image <img src="http://www.imio.be/contact.png"/>.</p>'
+        # image object does not exist for now
+        self.assertFalse('contact.png' in self.portal.objectIds())
+        self.assertEquals(storeExternalImagesLocally(doc, text),
+                          '<p>Working external image <img src="http://nohost/plone/contact.png"/>.</p>\n')
+        contact = self.portal.get('contact.png')
+        self.assertTrue(IImageContent.providedBy(contact))
+
+        # working example with a Folder, this test case where we have a container
+        # using RichText field, in this case the Image is stored in the Folder, not next to it
+        text = '<p>Working external image <img src="http://www.imio.be/mascotte-presentation.jpg"/>.</p>'
+        expected = '<p>Working external image <img src="http://nohost/plone/folder/mascotte-presentation.jpg"/>.</p>\n'
+        self.assertFalse('mascotte-presentation.jpg' in self.portal.folder.objectIds())
+        self.assertEquals(storeExternalImagesLocally(self.portal.folder, text), expected)
+        mascotte = self.portal.folder.get('mascotte-presentation.jpg')
+        self.assertTrue(IImageContent.providedBy(mascotte))

--- a/src/imio/helpers/xhtml.py
+++ b/src/imio/helpers/xhtml.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import cgi
 import lxml.html
 import types
+import urllib
 from Acquisition import aq_base
+from zope.container.interfaces import INameChooser
 from plone import api
 from Products.CMFPlone.utils import safe_unicode
 from plone.app.imaging.scale import ImageScale
@@ -222,5 +225,56 @@ def imagesToPath(context, xhtmlContent):
     # use encoding to 'ascii' so HTML entities are translated to something readable
     return ''.join([lxml.html.tostring(x,
                                        encoding='ascii',
+                                       pretty_print=True,
+                                       method='xml') for x in tree.iterchildren()])
+
+
+def storeExternalImagesLocally(context, xhtmlContent, imagePortalType='Image'):
+    """If external images are found in the given p_xhtmlContent,
+       we download it and stored it in p_context, this way we ensure that it will
+       always be available in case the external site/external image disappear."""
+    if not xhtmlContent or not xhtmlContent.strip():
+        return xhtmlContent
+
+    specialXhtmlContent = "<special_tag>%s</special_tag>" % xhtmlContent
+    tree = lxml.html.fromstring(safe_unicode(specialXhtmlContent))
+    imgs = tree.findall('.//img')
+    if not imgs:
+        return xhtmlContent
+    portal = api.portal.get()
+    portal_url = portal.absolute_url()
+    # adapter to generate a valid id, it needs a container, so it will be context or it's parent
+    try:
+        name_chooser = INameChooser(context)
+    except TypeError:
+        parent = context.getParentNode()
+        name_chooser = INameChooser(parent)
+    # return received xhtmlContent if nothing was changed
+    changed = False
+    for img in imgs:
+        img_src = img.attrib['src']
+        # a relative path or path is in the portal_url, we pass
+        if not img_src.startswith('http') or img_src.startswith(portal_url):
+            continue
+        # right, we have an external image, download it, stores it in context and update img_src
+        downloaded_img_path, downloaded_img_infos = urllib.urlretrieve(img_src)
+        if not downloaded_img_infos.maintype == 'image':
+            continue
+        changed = True
+        # retrieve filename
+        disp_value, disp_params = cgi.parse_header(downloaded_img_infos.getheader('Content-Disposition'))
+        filename = disp_params.get('filename', 'image')
+        name = name_chooser.chooseName(filename, context)
+        f = open(downloaded_img_path, 'r')
+        new_img_id = context.invokeFactory(imagePortalType, id=name, title=name, file=f.read())
+        f.close()
+        new_img = getattr(context, new_img_id)
+        img.attrib['src'] = new_img.absolute_url()
+
+    if not changed:
+        return xhtmlContent
+
+    return ''.join([lxml.html.tostring(x,
+                                       encoding='utf-8',
                                        pretty_print=True,
                                        method='xml') for x in tree.iterchildren()])


### PR DESCRIPTION
Added method xhtml.storeExternalImagesLocally that will ensure that externally referenced images are downloaded, stored locally and xhtmlContent is adapted accordingly.