### PR TITLE
Adapted `content.validate_fields` to bypass validation when field.required=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
   [sgeulette]
 - Added methods content.uuidsToCatalogBrains and content.uuidsToObjects.
   [gbastien]
+- Adapted `content.validate_fields` to bypass validation when field.required=False,
+  value is None and field type is other than Bool.
+  [gbastien]
 
 0.13 (2018-08-31)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Changelog
 - Added methods content.uuidsToCatalogBrains and content.uuidsToObjects.
   [gbastien]
 - Adapted `content.validate_fields` to bypass validation when field.required=False,
-  value is None and field type is other than Bool.
+  value is None and field type is other than Bool.  Validation is also bypassed for
+  field using a `source` attribute because it fails for now...
   [gbastien]
 - Added parameter raise_on_errors to content.validate_fields to raise a ValueError
   when errors are found instead simply returning it.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
 - Adapted `content.validate_fields` to bypass validation when field.required=False,
   value is None and field type is other than Bool.
   [gbastien]
+- Added parameter raise_on_errors to content.validate_fields to raise a ValueError
+  when errors are found instead simply returning it.
+  [gbastien]
 
 0.13 (2018-08-31)
 -----------------

--- a/src/imio/helpers/content.py
+++ b/src/imio/helpers/content.py
@@ -248,6 +248,13 @@ def validate_fields(obj, behaviors=True, raise_on_errors=False):
         # accept None for most of fields if required=False
         if value is None and not field.required and not (isinstance(field, (Bool, ))):
             continue
+        # we sadly have to bypass validation for field having a source as it fails
+        # because in plone.formwidget.contenttree source.py
+        # self._getBrainByToken('/'.join(value.getPhysicalPath()))
+        # raises 'RelationValue' object has no attribute 'getPhysicalPath'
+        if hasattr(field, 'source') and field.source is not None:
+            logger.warn("Bypassing validation of field '%s'" % field)
+            continue
         try:
             field._validate(value)
         except Exception, exc:

--- a/src/imio/helpers/profiles/testing/types/testingtype.xml
+++ b/src/imio/helpers/profiles/testing/types/testingtype.xml
@@ -39,6 +39,16 @@
            &lt;title&gt;Enabled&lt;/title&gt;
            &lt;required&gt;False&lt;/required&gt;
          &lt;/field&gt;
+         &lt;field name="textline" type="zope.schema.TextLine"&gt;
+           &lt;description/&gt;
+           &lt;title&gt;Text line&lt;/title&gt;
+           &lt;required&gt;False&lt;/required&gt;
+         &lt;/field&gt;
+         &lt;field name="mandatory_textline" type="zope.schema.TextLine"&gt;
+           &lt;description/&gt;
+           &lt;title&gt;Mandatory text line&lt;/title&gt;
+           &lt;required&gt;True&lt;/required&gt;
+         &lt;/field&gt;
        &lt;/schema&gt;
      &lt;/model&gt;
  </property>

--- a/src/imio/helpers/tests/test_content.py
+++ b/src/imio/helpers/tests/test_content.py
@@ -138,9 +138,10 @@ class TestContentModule(IntegrationTestCase):
                                  type='testingtype',
                                  enabled='Should be a boolean')
         self.assertListEqual([name for (name, fld) in get_schema_fields(obj=obj, behaviors=False)],
-                             ['text', 'enabled'])
+                             ['text', 'enabled', 'mandatory_textline', 'textline'])
         self.assertListEqual([name for (name, fld) in get_schema_fields(obj=obj)],
-                             ['text', 'enabled', 'description', 'title', 'title',
+                             ['text', 'enabled', 'mandatory_textline', 'textline',
+                              'description', 'title', 'title',
                               'tal_condition', 'roles_bypassing_talcondition'])
         self.assertListEqual([name for (name, fld) in get_schema_fields(type_name='portnawak')],
                              [])
@@ -151,6 +152,8 @@ class TestContentModule(IntegrationTestCase):
                                  id='tt',
                                  type='testingtype',
                                  enabled='Should be a boolean',
+                                 textline=None,
+                                 mandatory_textline=u'Some text',
                                  tal_condition=u'',
                                  roles_bypassing_talcondition=set())
         self.assertEqual(validate_fields(obj),
@@ -158,6 +161,13 @@ class TestContentModule(IntegrationTestCase):
         obj.enabled = False
         self.assertFalse(validate_fields(obj))
         obj.enabled = True
+        self.assertFalse(validate_fields(obj))
+        # not required fields other than Bool must contain something
+        # else than None if field is required=True
+        obj.mandatory_textline = None
+        self.assertEqual(validate_fields(obj),
+                         [WrongType(None, unicode, 'mandatory_textline')])
+        obj.mandatory_textline = u'Some text'
         self.assertFalse(validate_fields(obj))
 
     def test_safe_encode(self):


### PR DESCRIPTION
If field not required and value is None, we bypass validation except for field.Bool where we need a boolean to be stored.

Thank you for review and merge ;-)

Gauthier