### PR TITLE
Fix persistence problem in add/del annotation helper methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changelog
 - In `catalog.addOrUpdateIndexes`, pass a `ZLogHandler` to `reindexIndex` so the
   progress is shown in the Zope log.
   [gbastien]
+- In `content.add_to_annotation` and `content.del_from_annotation`, store
+  annotation in a `PersistentList` instead a `set()` to avoid persistence
+  problems.
+  [gbastien]
 
 0.14 (2018-10-22)
 -----------------

--- a/src/imio/helpers/content.py
+++ b/src/imio/helpers/content.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from persistent.list import PersistentList
 from plone import api
 from plone.api.validation import mutually_exclusive_parameters
 from plone.app.textfield.value import RichTextValue
@@ -288,8 +289,9 @@ def add_to_annotation(annotation_key, value, obj=None, uid=None):
 
     annot = IAnnotations(obj)
     if annotation_key not in annot:
-        annot[annotation_key] = set([])
-    annot[annotation_key].add(value)
+        annot[annotation_key] = PersistentList()
+    if value not in annot[annotation_key]:
+        annot[annotation_key].append(value)
 
 
 @mutually_exclusive_parameters('obj', 'uid')

--- a/src/imio/helpers/tests/test_content.py
+++ b/src/imio/helpers/tests/test_content.py
@@ -197,24 +197,24 @@ class TestContentModule(IntegrationTestCase):
         self.assertEqual(get_from_annotation('test_annot', uid=fakeUid, default='empty'), 'empty')
         # test add
         add_to_annotation('test_annot', 'tralala', uid=obj.UID())
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set(['tralala', ]))
+        self.assertEqual(IAnnotations(obj)['test_annot'], ['tralala'])
         add_to_annotation('test_annot', 'tralala', uid=obj.UID())
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set(['tralala', ]))
-        self.assertSetEqual(get_from_annotation('test_annot', obj=obj), set(['tralala', ]))
+        self.assertEqual(IAnnotations(obj)['test_annot'], ['tralala'])
+        self.assertEqual(get_from_annotation('test_annot', obj=obj), ['tralala'])
         add_to_annotation('test_annot', 'trilili', obj=obj)
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set(['tralala', 'trilili']))
+        self.assertEqual(IAnnotations(obj)['test_annot'], ['tralala', 'trilili'])
         # add value with uid that doesn't match an object raises no error.
         add_to_annotation('test_annot', 'tralala', uid='znfzete tztzfozaebfozaefg')
         # test remove
         del_from_annotation('test_annot', 'tralala', uid=obj.UID())
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set(['trilili', ]))
+        self.assertEqual(IAnnotations(obj)['test_annot'], ['trilili'])
         del_from_annotation('test_annot', 'trilili', uid=obj.UID())
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set([]))
+        self.assertEqual(IAnnotations(obj)['test_annot'], [])
         # remove value with uid that doesn't match an object raises no error.
         del_from_annotation('test_annot', 'tralala', uid=fakeUid)
         # remove value that doesn't exist in set
         del_from_annotation('test_annot', 'trololo', uid=obj.UID())
-        self.assertSetEqual(IAnnotations(obj)['test_annot'], set([]))
+        self.assertEqual(IAnnotations(obj)['test_annot'], [])
         # remove value from a no-existing key in annotation
         self.assertIsNone(del_from_annotation('test_not_key_in_annot', 'trololo', uid=obj.UID()))
 


### PR DESCRIPTION
In `content.add_to_annotation` and `content.del_from_annotation`, store annotation in a `PersistentList` instead a `set()` to avoid persistence problems.

I had this problem when using instance1 without ZEO and a setup of PODTemplates reusing other PODTemplates odt_file.

Moving from set() to PersistentList solved the problem but I do not know if set() was required.

Was this already used by anyone in documentgenerator, if so we need a migration...

Gauthier