### PR TITLE
Fixed `cache.obj_modified` when checking annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changelog
 0.74 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Fixed `cache.obj_modified` when checking annotations, take care that `_p_mtime`
+  is not changed on `__annotations__` when a value changes in a stored annotation
+  that is a `PersistentMapping`.
+  Also removed parameter `asstring=False`, when `asdatetime=False`, returned
+  value is float which is convenient to be used in a cachekey.
+  [gbastien]
 
 0.73 (2023-07-20)
 -----------------

--- a/src/imio/helpers/testing.py
+++ b/src/imio/helpers/testing.py
@@ -94,6 +94,7 @@ class IntegrationTestCase(unittest.TestCase):
         super(IntegrationTestCase, self).setUp()
         self.portal = self.layer['portal']
         self.portal_url = self.portal.absolute_url()
+        self.request = self.portal.REQUEST
         self.catalog = self.portal.portal_catalog
 
         sml = getSiteManager(self.portal)

--- a/src/imio/helpers/tests/test_fancytree.py
+++ b/src/imio/helpers/tests/test_fancytree.py
@@ -32,24 +32,24 @@ class TestBaseRenderFancyTree(IntegrationTestCase):
     """Test BaseRenderFancyTree view."""
 
     def test_label(self):
-        view = BaseRenderFancyTree(self.portal, self.portal.REQUEST)
+        view = BaseRenderFancyTree(self.portal, self.request)
         self.assertEqual(view.label(), 'Plone site')
 
     def test_redirect_url(self):
-        view = BaseRenderFancyTree(self.portal, self.portal.REQUEST)
+        view = BaseRenderFancyTree(self.portal, self.request)
         with self.assertRaises(NotImplementedError):
             view.redirect_url('some_uid')
 
     def test_get_query(self):
-        view = BaseRenderFancyTree(self.portal, self.portal.REQUEST)
+        view = BaseRenderFancyTree(self.portal, self.request)
         with self.assertRaises(NotImplementedError):
             view.get_query()
 
     def test_call(self):
-        view = RenderFancyTreeExample(self.portal, self.portal.REQUEST)
+        view = RenderFancyTreeExample(self.portal, self.request)
         self.assertEqual(view(), "index")
 
-        request = self.portal.REQUEST
+        request = self.request
         request.method = 'POST'
         request['uid'] = 'myuid'
         self.assertEqual(view(), '')
@@ -57,7 +57,7 @@ class TestBaseRenderFancyTree(IntegrationTestCase):
 
     def test_get_data(self):
         """Test get_data method."""
-        view = RenderFancyTreeExample(self.portal, self.portal.REQUEST)
+        view = RenderFancyTreeExample(self.portal, self.request)
         self.assertEqual(view.get_data(), '[]')
 
         # add some folders and documents


### PR DESCRIPTION
Take care that `_p_mtime` is not changed on `__annotations__` when a value changes in a stored annotation that is a `PersistentMapping`. Also removed parameter `asstring=False`, when `asdatetime=False`, returned value is float which is convenient to be used in a cachekey.

See #MOD-964