### PR TITLE
Fixed setup.load_type_from_package when loading a Dexterity FTI because it fails to purge old values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 0.75 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Fixed setup.load_type_from_package when loading a Dexterity FTI because it fails to purge old values.
+  Purging is disabled for Dexterity FTI, we just manage removing actions manually so it is reloaded in correct order.
+  [gbastien]
 
 0.74 (2023-08-24)
 -----------------

--- a/src/imio/helpers/setup.py
+++ b/src/imio/helpers/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from plone import api
+from plone.dexterity.fti import DexterityFTI
 from Products.GenericSetup.utils import importObjects
 
 import logging
@@ -34,7 +35,7 @@ def load_workflow_from_package(wkf_name, profile_id):
     return True
 
 
-def load_type_from_package(type_name, profile_id):
+def load_type_from_package(type_name, profile_id, purge_actions=False):
     """Loads a portal_type from his xml definition.
     :param type_name: portal_type id
     :param profile_id: package profile id
@@ -51,6 +52,15 @@ def load_type_from_package(type_name, profile_id):
     except KeyError:
         logger.error("Cannot find '{}' profile id".format(profile_id))
         return False
+
+    # special case for DX FTI, _should_purge is set to False or it fails when purging
+    if isinstance(portal_type, DexterityFTI):
+        context._should_purge = False
+
+    if purge_actions:
+        # remove actions so it is reloaded in correct order
+        portal_type._actions = ()
+
     # ps_tool.applyContext(context)  # necessary ?
     importObjects(portal_type, 'types/', context)
     if portal_type._p_changed is False:

--- a/src/imio/helpers/tests/test_setup.py
+++ b/src/imio/helpers/tests/test_setup.py
@@ -54,3 +54,9 @@ class TestSetupModule(IntegrationTestCase):
         # type not managed by given profile_id
         self.assertFalse(load_type_from_package(
             'testingtype', 'profile-Products.CMFPlone:plone'))
+        # reimport a Dexterity fti
+        self.assertTrue(load_type_from_package(
+            'testingtype', 'profile-imio.helpers:testing'))
+        # with purge_actions=True
+        self.assertTrue(load_type_from_package(
+            'testingtype', 'profile-imio.helpers:testing', purge_actions=True))


### PR DESCRIPTION
Purging is disabled for Dexterity FTI, we just manage removing actions manually so it is reloaded in correct order. See #PM-4064