### PR TITLE
Monkeypatched `plone.app.querystring.registryreader.getVocabularyValues` to keep vocabulary order.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Changelog
 - Overrided `@@folder_contents` to make it work with `DashboardCollection`.
   [gbastien]
 - Monkeypatched `plone.app.querystring.registryreader.getVocabularyValues`
-  to keep vocabulary order.
+  to keep vocabulary order onloy for Plone4, behavior is correct in Plone5+.
   Manage every `HAS_PLONE_X` values.
   [gbastien]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Changelog
   [gbastien]
 - Overrided `@@folder_contents` to make it work with `DashboardCollection`.
   [gbastien]
+- Monkeypatched `plone.app.querystring.registryreader.getVocabularyValues`
+  to keep vocabulary order.
+  Manage every `HAS_PLONE_X` values.
+  [gbastien]
 
 1.0.0rc1 (2024-02-08)
 ---------------------

--- a/src/imio/helpers/__init__.py
+++ b/src/imio/helpers/__init__.py
@@ -16,6 +16,10 @@ import os
 _ = MessageFactory('imio.helpers')
 logger = logging.getLogger('imio.helpers')
 
+HAS_PLONE_4 = api.env.plone_version().startswith('4')
+HAS_PLONE_5 = api.env.plone_version().startswith('5')
+HAS_PLONE_5_1 = api.env.plone_version() > '5.1'
+HAS_PLONE_5_2 = api.env.plone_version() > '5.2'
 HAS_PLONE_5_AND_MORE = int(api.env.plone_version()[0]) >= 5
 PLONE_MAJOR_VERSION = int(api.env.plone_version()[0])
 

--- a/src/imio/helpers/browser/views.py
+++ b/src/imio/helpers/browser/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from Acquisition import aq_inner
+from imio.helpers import HAS_PLONE_4
 from imio.helpers.interfaces import IListContainedDexterityObjectsForDisplay
 from plone import api
 from plone.app.caching.browser.controlpanel import RAMCache
@@ -9,8 +10,6 @@ from plone.dexterity.browser.view import DefaultView
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 
-
-HAS_PLONE_4 = api.env.plone_version().startswith('4')
 
 if HAS_PLONE_4:
     from plone.app.content.browser.foldercontents import FolderContentsBrowserView

--- a/src/imio/helpers/configure.zcml
+++ b/src/imio/helpers/configure.zcml
@@ -90,7 +90,7 @@
         replacement=".patches._listAllowedRolesAndUsers"
         preserveOriginal="true" />
 
-    <monkey:patch
+    <monkey:patch zcml:condition="have plone-4"
         description="Monkeypatch getVocabularyValues from plone.app.querystring to keep vocabulary order"
         class="plone.app.querystring.registryreader.QuerystringRegistryReader"
         original="getVocabularyValues"

--- a/src/imio/helpers/configure.zcml
+++ b/src/imio/helpers/configure.zcml
@@ -90,6 +90,13 @@
         replacement=".patches._listAllowedRolesAndUsers"
         preserveOriginal="true" />
 
+    <monkey:patch
+        description="Monkeypatch getVocabularyValues from plone.app.querystring to keep vocabulary order"
+        class="plone.app.querystring.registryreader.QuerystringRegistryReader"
+        original="getVocabularyValues"
+        replacement=".patches.getVocabularyValues"
+        preserveOriginal="true" />
+
     <utility component=".vocabularies.SortedUsersFactory"
              name="imio.helpers.SortedUsers" />
 

--- a/src/imio/helpers/content.py
+++ b/src/imio/helpers/content.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from imio.helpers import HAS_PLONE_5_AND_MORE
 from imio.helpers.interfaces import IContainerOfUnindexedElementsMarker
 from imio.helpers.workflow import do_transitions
 from imio.pyutils.utils import safe_encode  # noqa, temporary import for backward compatibility as was also defined here
@@ -31,8 +32,7 @@ import logging
 import os
 
 
-HAS_PLONE5 = bool(getFSVersionTuple()[0] >= 5)
-if HAS_PLONE5:
+if HAS_PLONE_5_AND_MORE:
     from Products.CMFPlone.interfaces import IEditingSchema
 
 logger = logging.getLogger('imio.helpers.content')


### PR DESCRIPTION
Manage every `HAS_PLONE_X` values.
See #MOD-987