### PR TITLE
Fix double quoted email address validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.3.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix double quoted email address validation.
+  [chris-adam]
 
 
 1.3.14 (2026-04-14)

--- a/src/imio/helpers/emailer.py
+++ b/src/imio/helpers/emailer.py
@@ -249,8 +249,13 @@ def validate_email_address(value):
     # Use parseaddr only when necessary to avoid correction like 'a @d.c' => 'a@d.c'
     # or to avoid bad split like 'a<a@d.c' => 'a@d.c'
     if complex_form:
-        if '""' in eml:  # '"\\"' ends with '""' and must be corrected. We choose to un-double the doublequotes
-            eml = re.sub(r'""([^"<]+)""\s*<(.*)>', r'"\1" <\2>', eml)
+        if eml.startswith('""'):  # '"\\"' ends with '""' and must be corrected. We choose to un-double the doublequotes
+            eml = re.sub(r'^""(.*?)""?\s*<', r'"\1" <', eml)
+            m = re.match(r'^"(.*)"\s*<(.*)>', eml)
+            if m:
+                name_part, addr_part = m.groups()
+                clean_name = name_part.replace('"', '')
+                eml = u'"{}" <{}>'.format(clean_name, addr_part)
         realname, eml = parseaddr(eml)
         if not realname and not eml:
             raise InvalidEmailAddressFormat(value)

--- a/src/imio/helpers/tests/test_email.py
+++ b/src/imio/helpers/tests/test_email.py
@@ -174,6 +174,10 @@ class TestEmail(IntegrationTestCase):
         )
         self.assertTupleEqual(validate_email_address("Real Name <name@domain.org>"), (u"Real Name", u"name@domain.org"))
         self.assertTupleEqual(validate_email_address("name@domain.org (Real Name)"), (u"Real Name", u"name@domain.org"))
+        self.assertTupleEqual(
+            validate_email_address("\"\"Real name\", Long real name\" <name@domain.org>"),
+            (u"Real name, Long real name", u"name@domain.org"),
+        )
         # errors on format
         self.assertRaises(InvalidEmailAddressFormat, validate_email_address, "<>")
         self.assertRaises(InvalidEmailAddressFormat, validate_email_address, "()")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complex email formats with embedded quotes so real names and addresses are normalized and validated correctly.
* **Tests**
  * Added a test asserting correct parsing of quoted/escaped real-name values in email addresses.
* **Chores**
  * Updated unreleased changelog entry to note the email validation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->