### PR TITLE
Added create parameter in `setup.load_type_from_package` and `setup.l…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Try to avoid being blocked when downloading image in
   `xhtml.storeImagesLocally` by setting a `User-agent` header.
   [gbastien]
+- Added create parameter in `setup.load_type_from_package` and `setup.load_workflow_from_package` to create the type
+  or workflow if it does not exist.
+  [sgeulette]
 
 1.3.16 (2026-05-29)
 -------------------

--- a/src/imio/helpers/setup.py
+++ b/src/imio/helpers/setup.py
@@ -23,22 +23,26 @@ def load_type_from_package(type_name, profile_id, purge_actions=False, create=Fa
     :return: status as boolean
     """
     types_tool = api.portal.get_tool("portal_types")
-    portal_type = types_tool.get(type_name)
-    created = False
-    if portal_type is None:
-        if not create:
-            logger.error("Cannot find '{}' portal_type name in portal".format(type_name))
-            return False
-        # first load: create an empty Dexterity FTI so importObjects can fill it from the xml
-        types_tool._setObject(type_name, DexterityFTI(type_name))
-        portal_type = types_tool.get(type_name)
-        created = True
     ps_tool = api.portal.get_tool("portal_setup")
     try:
         context = ps_tool._getImportContext(profile_id, True)
     except KeyError:
         logger.error("Cannot find '{}' profile id".format(profile_id))
         return False
+    if context.readDataFile("types/%s.xml" % type_name) is None:
+        logger.error("No type xml definition for '{}' in profile '{}'".format(type_name, profile_id))
+        return False
+    portal_type = types_tool.get(type_name)
+    created = False
+    if portal_type is None:
+        if not create:
+            logger.error("Cannot find '{}' portal_type name in portal".format(type_name))
+            return False
+
+        # first load: create an empty Dexterity FTI so importObjects can fill it from the xml
+        types_tool._setObject(type_name, DexterityFTI(type_name))
+        portal_type = types_tool.get(type_name)
+        created = True
 
     # special case for DX FTI, _should_purge is set to False or it fails when purging
     if isinstance(portal_type, DexterityFTI):
@@ -67,6 +71,15 @@ def load_workflow_from_package(wkf_name, profile_id, purge_workflow=True, create
     :return: status as boolean
     """
     wkf_tool = api.portal.get_tool("portal_workflow")
+    ps_tool = api.portal.get_tool("portal_setup")
+    try:
+        context = ps_tool._getImportContext(profile_id, True)
+    except KeyError:
+        logger.error("Cannot find '{}' profile id".format(profile_id))
+        return False
+    if context.readDataFile("workflows/%s/definition.xml" % wkf_name) is None:
+        logger.error("No workflow xml definition for '{}' in profile '{}'".format(wkf_name, profile_id))
+        return False
     wkf_obj = wkf_tool.get(wkf_name)
     created = False
     if wkf_obj is None:
@@ -81,12 +94,6 @@ def load_workflow_from_package(wkf_name, profile_id, purge_workflow=True, create
     if purge_workflow:
         wkf_obj.states.deleteStates(list(wkf_obj.states.keys()))
         wkf_obj.transitions.deleteTransitions(list(wkf_obj.transitions.keys()))
-    ps_tool = api.portal.get_tool("portal_setup")
-    try:
-        context = ps_tool._getImportContext(profile_id, True)
-    except KeyError:
-        logger.error("Cannot find '{}' profile id".format(profile_id))
-        return False
     # ps_tool.applyContext(context)  # necessary ?
     importObjects(wkf_obj, "workflows/", context)
     logger.info("'%s' workflow info imported", wkf_name)

--- a/src/imio/helpers/setup.py
+++ b/src/imio/helpers/setup.py
@@ -3,6 +3,7 @@
 from plone import api
 from plone.api.exc import InvalidParameterError
 from plone.dexterity.fti import DexterityFTI
+from Products.DCWorkflow.DCWorkflow import DCWorkflowDefinition
 from Products.GenericSetup.interfaces import IBody
 from Products.GenericSetup.utils import importObjects
 from zope.component import queryMultiAdapter
@@ -13,18 +14,25 @@ import logging
 logger = logging.getLogger("imio.helpers.setup")
 
 
-def load_type_from_package(type_name, profile_id, purge_actions=False):
+def load_type_from_package(type_name, profile_id, purge_actions=False, create=False):
     """Loads a portal_type from his xml definition.
     :param type_name: portal_type id
     :param profile_id: package profile id
     :param purge_actions: empties type actions
+    :param create: create an empty Dexterity FTI when the type does not exist yet (first load)
     :return: status as boolean
     """
     types_tool = api.portal.get_tool("portal_types")
     portal_type = types_tool.get(type_name)
+    created = False
     if portal_type is None:
-        logger.error("Cannot find '{}' portal_type name in portal".format(type_name))
-        return False
+        if not create:
+            logger.error("Cannot find '{}' portal_type name in portal".format(type_name))
+            return False
+        # first load: create an empty Dexterity FTI so importObjects can fill it from the xml
+        types_tool._setObject(type_name, DexterityFTI(type_name))
+        portal_type = types_tool.get(type_name)
+        created = True
     ps_tool = api.portal.get_tool("portal_setup")
     try:
         context = ps_tool._getImportContext(profile_id, True)
@@ -42,24 +50,34 @@ def load_type_from_package(type_name, profile_id, purge_actions=False):
 
     # ps_tool.applyContext(context)  # necessary ?
     importObjects(portal_type, "types/", context)
-    if portal_type._p_changed is False:
+    # a freshly created fti fills sub-attributes: _p_changed on the fti itself may stay False
+    if not created and portal_type._p_changed is False:
         logger.error("Could not update '{}' using profile '{}'".format(type_name, profile_id))
         return False
     return True
 
 
-def load_workflow_from_package(wkf_name, profile_id, purge_workflow=True):
+def load_workflow_from_package(wkf_name, profile_id, purge_workflow=True, create=False):
     """Loads a workflow from his xml definition.
     :param wkf_name: workflow id
     :param profile_id: package profile id
     :param purge_workflow: remove states and transitions before loading
+    :param create: create an empty DCWorkflow when the workflow does not exist yet (first load).
+                   Note: the type/workflow binding (stored in workflows.xml) still has to be set separately.
     :return: status as boolean
     """
     wkf_tool = api.portal.get_tool("portal_workflow")
     wkf_obj = wkf_tool.get(wkf_name)
+    created = False
     if wkf_obj is None:
-        logger.error("Cannot find '{}' workflow name in portal".format(wkf_name))
-        return False
+        if not create:
+            logger.error("Cannot find '{}' workflow name in portal".format(wkf_name))
+            return False
+        # first load: create an empty DCWorkflow so importObjects can fill it from the xml
+        wkf_tool._setObject(wkf_name, DCWorkflowDefinition(wkf_name))
+        wkf_obj = wkf_tool.get(wkf_name)
+        purge_workflow = False  # brand new workflow, nothing to purge
+        created = True
     if purge_workflow:
         wkf_obj.states.deleteStates(list(wkf_obj.states.keys()))
         wkf_obj.transitions.deleteTransitions(list(wkf_obj.transitions.keys()))
@@ -71,7 +89,10 @@ def load_workflow_from_package(wkf_name, profile_id, purge_workflow=True):
         return False
     # ps_tool.applyContext(context)  # necessary ?
     importObjects(wkf_obj, "workflows/", context)
-    if wkf_obj._p_changed is False:
+    logger.info("'%s' workflow info imported", wkf_name)
+    # a freshly created workflow fills its states/transitions sub-objects: _p_changed on the
+    # workflow itself may stay False
+    if not created and wkf_obj._p_changed is False:
         logger.error("Could not update '{}' using profile '{}'".format(wkf_name, profile_id))
         return False
     return True

--- a/src/imio/helpers/tests/test_setup.py
+++ b/src/imio/helpers/tests/test_setup.py
@@ -48,6 +48,15 @@ class TestSetupModule(IntegrationTestCase):
         self.assertTrue(load_type_from_package("testingtype", "profile-imio.helpers:testing"))
         # with purge_actions=True
         self.assertTrue(load_type_from_package("testingtype", "profile-imio.helpers:testing", purge_actions=True))
+        # first load: the type does not exist yet
+        types_tool.manage_delObjects(["testingtype"])
+        self.assertIsNone(types_tool.get("testingtype"))
+        # without create=True, a missing type still fails
+        self.assertFalse(load_type_from_package("testingtype", "profile-imio.helpers:testing"))
+        self.assertIsNone(types_tool.get("testingtype"))
+        # with create=True, the empty fti is created then filled from the xml
+        self.assertTrue(load_type_from_package("testingtype", "profile-imio.helpers:testing", create=True))
+        self.assertIsNotNone(types_tool.get("testingtype"))
 
     def test_load_workflow_from_package(self):
         wkf_tool = api.portal.get_tool("portal_workflow")
@@ -73,6 +82,19 @@ class TestSetupModule(IntegrationTestCase):
         self.assertFalse(load_workflow_from_package("intranet_workflow", "profile-Products.CMFPlone:plone2"))
         # WF not managed by given profile_id
         self.assertFalse(load_workflow_from_package("comment_review_workflow", "profile-Products.CMFPlone:plone"))
+        # first load: the workflow does not exist yet
+        wkf_tool.manage_delObjects(["intranet_workflow"])
+        self.assertIsNone(wkf_tool.get("intranet_workflow"))
+        # without create=True, a missing workflow still fails
+        self.assertFalse(load_workflow_from_package("intranet_workflow", "profile-Products.CMFPlone:plone"))
+        self.assertIsNone(wkf_tool.get("intranet_workflow"))
+        # with create=True, the empty DCWorkflow is created then filled from the xml
+        self.assertTrue(
+            load_workflow_from_package("intranet_workflow", "profile-Products.CMFPlone:plone", create=True)
+        )
+        wkf_obj = wkf_tool.get("intranet_workflow")
+        self.assertIsNotNone(wkf_obj)
+        self.assertIn("internal", wkf_obj.states)
 
     @unittest.skip("Not working")
     def test_load_xml_tool_only_from_package(self):

--- a/src/imio/helpers/tests/test_setup.py
+++ b/src/imio/helpers/tests/test_setup.py
@@ -54,6 +54,9 @@ class TestSetupModule(IntegrationTestCase):
         # without create=True, a missing type still fails
         self.assertFalse(load_type_from_package("testingtype", "profile-imio.helpers:testing"))
         self.assertIsNone(types_tool.get("testingtype"))
+        # with create=True but a profile that has no xml for this type: no empty object is created
+        self.assertFalse(load_type_from_package("testingtype", package, create=True))
+        self.assertIsNone(types_tool.get("testingtype"))
         # with create=True, the empty fti is created then filled from the xml
         self.assertTrue(load_type_from_package("testingtype", "profile-imio.helpers:testing", create=True))
         self.assertIsNotNone(types_tool.get("testingtype"))
@@ -87,6 +90,11 @@ class TestSetupModule(IntegrationTestCase):
         self.assertIsNone(wkf_tool.get("intranet_workflow"))
         # without create=True, a missing workflow still fails
         self.assertFalse(load_workflow_from_package("intranet_workflow", "profile-Products.CMFPlone:plone"))
+        self.assertIsNone(wkf_tool.get("intranet_workflow"))
+        # with create=True but a profile that has no xml for this workflow: no empty object is created
+        self.assertFalse(
+            load_workflow_from_package("intranet_workflow", "profile-imio.helpers:testing", create=True)
+        )
         self.assertIsNone(wkf_tool.get("intranet_workflow"))
         # with create=True, the empty DCWorkflow is created then filled from the xml
         self.assertTrue(


### PR DESCRIPTION
…oad_workflow_from_package` to create the type or workflow if it does not exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal types and workflows can now be automatically created during package imports when they don’t already exist (via a new “create” option).
* **Bug Fixes**
  * Import reliability improved by skipping change-detection checks when the target object was just created.
  * Added coverage for “create-on-missing” behavior, including cases where the profile lacks the required XML (no empty objects created).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->