### PR TITLE
PARAF-492: Fixed PDF merge when source PDF has no /Root in trailer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog
 - Added create parameter in `setup.load_type_from_package` and `setup.load_workflow_from_package` to create the type
   or workflow if it does not exist.
   [sgeulette]
+- Fixed PDF merge when source PDF has no /Root in trailer. (PARAF-492)
+  [chris-adam]
 
 1.3.16 (2026-05-29)
 -------------------

--- a/src/imio/helpers/pdf.py
+++ b/src/imio/helpers/pdf.py
@@ -4,6 +4,9 @@
 from imio.helpers import barcode
 from PyPDF2 import PdfReader
 from PyPDF2 import PdfWriter
+from PyPDF2.errors import PdfReadError
+from PyPDF2.generic import IndirectObject
+from PyPDF2.generic import NameObject
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 from reportlab.platypus import Flowable
@@ -13,6 +16,29 @@ from reportlab.platypus.flowables import Image
 import io
 import os
 import uuid
+
+
+def read_pdf(stream):
+    """Build a PdfReader, recovering /Root for malformed PDFs.
+
+    Some source PDFs (e.g. badly linearized ones) end with a trailer that has
+    no /Root; PyPDF2's xref rebuild then yields a reader whose trailer lacks
+    /Root, so any page access raises KeyError('/Root'). Recover by locating the
+    /Catalog object and pointing /Root at it.
+    """
+    reader = PdfReader(stream)
+    if "/Root" in reader.trailer:
+        return reader
+    for gen, idmap in reader.xref.items():
+        for idnum in idmap:
+            try:
+                obj = IndirectObject(idnum, gen, reader).get_object()
+            except Exception:
+                continue
+            if getattr(obj, "get", None) and obj.get("/Type") == "/Catalog":
+                reader.trailer[NameObject("/Root")] = IndirectObject(idnum, gen, reader)
+                return reader
+    raise PdfReadError("PDF trailer has no /Root and no /Catalog object was found")
 
 
 class BarcodeStamp(object):
@@ -82,7 +108,7 @@ class BarcodeStamp(object):
         output_writer = PdfWriter()
         stamp = PdfReader(open(stamp_path, "rb"))
         content_file = open(self.filepath, "rb")
-        content = PdfReader(content_file)
+        content = read_pdf(content_file)
         counter = 0
         for page in content.pages:
             if counter == 0:
@@ -124,7 +150,7 @@ def merge_pdf(*pdf_datas):
     """
     writer = PdfWriter()
     for data in pdf_datas:
-        reader = PdfReader(io.BytesIO(data))
+        reader = read_pdf(io.BytesIO(data))
         for page in reader.pages:
             (getattr(writer, "add_page", None) or writer.addPage)(page)
     output = io.BytesIO()

--- a/src/imio/helpers/tests/test_pdf.py
+++ b/src/imio/helpers/tests/test_pdf.py
@@ -7,6 +7,7 @@ from PyPDF2 import PdfReader
 from PyPDF2.errors import PdfReadError
 from reportlab.pdfgen import canvas
 
+import re
 import unittest
 
 
@@ -38,3 +39,16 @@ class TestPdf(unittest.TestCase):
 
         # merge_pdf raises an exception when given invalid PDF data
         self.assertRaises(PdfReadError, merge_pdf, b"not a pdf", b"not a pdf")
+
+    def test_merge_pdf_recovers_missing_root(self):
+        # a source PDF whose trailer lacks /Root must not break the merge
+        no_root = re.sub(b"/Root\\s+\\d+\\s+\\d+\\s+R", b"", _make_pdf(1), count=1)
+        self.assertRaises(KeyError, _pdf_page_count, no_root)  # confirms the fixture
+        result = merge_pdf(no_root, _make_pdf(2))
+        self.assertEqual(_pdf_page_count(result), 3)
+
+    def test_merge_pdf_no_root_no_catalog_raises(self):
+        # unrecoverable: trailer lacks /Root and no /Catalog object exists
+        no_root = re.sub(b"/Root\\s+\\d+\\s+\\d+\\s+R", b"", _make_pdf(1), count=1)
+        unrecoverable = no_root.replace(b"/Catalog", b"/Xatalog")
+        self.assertRaises(PdfReadError, merge_pdf, unrecoverable, _make_pdf(1))


### PR DESCRIPTION
## Summary

Fixes `KeyError: '/Root'` when merging a source PDF whose trailer lacks `/Root`
(seen with a badly-linearized PDF during the imio.dms.mail esign approval flow:
`OMApprovalAdapter._create_pdf_file` → `imio.helpers.pdf.merge_pdf`).

PyPDF2 1.28.6 detects the broken `startxref` (`incorrect startxref pointer(3)`),
falls back to `_rebuild_xref_table`, and copies trailer keys only from the last
`trailer` keyword — which has no `/Root`. Any page access then raises
`KeyError('/Root')`, even though a valid `/Catalog` object is present in the file.

## Fix

- New `read_pdf(stream)` helper: builds the `PdfReader` and, when `/Root` is
  missing from the trailer, locates the `/Type /Catalog` object and points
  `/Root` at it. Raises `PdfReadError` if no catalog exists (unrecoverable).
- Routed both source-PDF readers through it: `merge_pdf` and
  `BarcodeStamp._merge_pdf` (sibling caller with the identical latent bug).
  The app-generated stamp reader is left untouched.

## Tests

- `test_merge_pdf_recovers_missing_root` — source PDF with `/Root` stripped merges correctly.
- `test_merge_pdf_no_root_no_catalog_raises` — unrecoverable input raises `PdfReadError`.

## Jira

PARAF-492 — https://support-imio.atlassian.net/browse/PARAF-492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF merging for files with missing trailer metadata when the document catalog can be recovered.
  * Added clear error handling for malformed PDFs that cannot be recovered.
  * Updated the changelog with this fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->