### PR TITLE
In `vocabularies.get_users_voc` use `@@pas_search` to get users so it will merge user infos from various sources, including `mutable_properties` to workaround `SIZELIMIT_EXCEEDED: {'desc': 'Size limit exceeded'}` when using LDAP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,15 @@ Changelog
 - Try to avoid being blocked when downloading image in
   `xhtml.storeImagesLocally` by setting a `User-agent` header.
   [gbastien]
-- Added create parameter in `setup.load_type_from_package` and `setup.load_workflow_from_package` to create the type
-  or workflow if it does not exist.
+- Added create parameter in `setup.load_type_from_package` and
+  `setup.load_workflow_from_package` to create the type or workflow
+  if it does not exist.
   [sgeulette]
+- In `vocabularies.get_users_voc` use `@@pas_search` to get users so it will
+  merge user infos from various sources, including `mutable_properties` to
+  workaround `SIZELIMIT_EXCEEDED: {'desc': 'Size limit exceeded'}`
+  when using LDAP.
+  [gbastien]
 
 1.3.16 (2026-05-29)
 -------------------

--- a/src/imio/helpers/vocabularies.py
+++ b/src/imio/helpers/vocabularies.py
@@ -2,6 +2,7 @@
 
 from imio.helpers import get_cachekey_volatile
 from imio.helpers.content import get_user_fullname
+from itertools import chain
 from natsort import humansorted
 from operator import attrgetter
 from plone import api
@@ -30,8 +31,10 @@ def voc_cache_key(method, self, context=None, query=""):
 
 
 def get_users_voc(with_userid):
-    acl_users = api.portal.get_tool("acl_users")
-    users = acl_users.searchUsers(sort_by="")
+    portal = api.portal.get()
+    search_view = portal.restrictedTraverse('@@pas_search')
+    users = search_view.merge(
+        chain(*[search_view.searchUsers() for field in ['name', 'fullname', 'email']]), 'userid')
     terms = []
     # manage duplicates, this can be the case when using LDAP and same userid in source_users
     userids = []

--- a/src/imio/helpers/vocabularies.py
+++ b/src/imio/helpers/vocabularies.py
@@ -33,8 +33,7 @@ def voc_cache_key(method, self, context=None, query=""):
 def get_users_voc(with_userid):
     portal = api.portal.get()
     search_view = portal.restrictedTraverse('@@pas_search')
-    users = search_view.merge(
-        chain(*[search_view.searchUsers() for field in ['name', 'fullname', 'email']]), 'userid')
+    users = search_view.merge(chain(*[search_view.searchUsers()]), 'userid')
     terms = []
     # manage duplicates, this can be the case when using LDAP and same userid in source_users
     userids = []


### PR DESCRIPTION
See #SUP-54377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user vocabulary generation by merging user details (username, full name, email) from multiple search results.
  * Helped ensure complete user listings by avoiding failures caused by directory search size limits.

* **Documentation**
  * Updated the changelog to clarify that types and workflows are created automatically when they don’t already exist.
  * Added a changelog note describing the updated user search/merging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->